### PR TITLE
Fixes a bug related to list CSS styles being reset by SLDS CSS in SF LWC.

### DIFF
--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.css
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.css
@@ -78,6 +78,20 @@ lightning-service-cloud-voice-toolkit-api {
   display: flex;
 }
 
+/* Ensures default list styling is present, which SLDS resets. Affects GKA and Agent Coaching suggestions */
+.agent-assist-ui-modules ol,
+.agent-assist-ui-modules ul {
+  padding-inline-start: 1rem;
+}
+
+.agent-assist-ui-modules ul {
+  list-style-type: disc;
+}
+
+.agent-assist-ui-modules ol {
+  list-style-type: decimal;
+}
+
 /* Adds consistent vertical padding to the suggestions container */
 .agent-assist-ui-modules 
   .main

--- a/salesforce/aa-lwc/setup.sh
+++ b/salesforce/aa-lwc/setup.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+UIM_TRANSCRIPT_VERSION='v1.3'
+UIM_CONTAINER_VERSION='v2.3'
+UIM_COMMON_VERSION='v1.11'
+
 if [[ $1 == 'generate-static-resources' ]]; then
   # UI Modules Javascript
   # https://cloud.google.com/agent-assist/docs/ui-modules#agent-assist-features
@@ -26,7 +30,7 @@ if [[ $1 == 'generate-static-resources' ]]; then
   file_path=${dir_path}/${file}.js
   rm -f ${file_path} # delete file if exists
   rm -f ${file_path}.resource-meta.xml # delete file if exists
-  curl --silent https://www.gstatic.com/agent-assist-ui-modules/v1.3/${file}.js > $file_path
+  curl --silent https://www.gstatic.com/agent-assist-ui-modules/${UIM_TRANSCRIPT_VERSION}/${file}.js > $file_path
   echo downloaded js and wrote ${file_path}
 
   # download container.js
@@ -34,10 +38,10 @@ if [[ $1 == 'generate-static-resources' ]]; then
   file_path=${dir_path}/${file}.js
   rm -f ${file_path} # delete file if exists
   rm -f ${file_path}.resource-meta.xml # delete file if exists
-  # pin the UIM container version to a version e.g. v2.3
-  curl --silent https://www.gstatic.com/agent-assist-ui-modules/v2.3/${file}.js > $file_path
+  # pin the UIM container version to a version
+  curl --silent https://www.gstatic.com/agent-assist-ui-modules/${UIM_CONTAINER_VERSION}/${file}.js > $file_path
   # or, use a localized version of the UIM container, e.g. 'it' for Italian, 'de' for German:
-  # curl --silent https://www.gstatic.com/agent-assist-ui-modules/it/v2.3/container.js
+  # curl --silent https://www.gstatic.com/agent-assist-ui-modules/it/${UIM_CONTAINER_VERSION}/${file}.js
   # or, try the latest UIM v2 changes (auto updates)
   # curl --silent https://www.gstatic.com/agent-assist-ui-modules/v2/${file}.js > $file_path
   echo downloaded js and wrote ${file_path}
@@ -47,7 +51,7 @@ if [[ $1 == 'generate-static-resources' ]]; then
   file_path=${dir_path}/${file}.js
   rm -f ${file_path} # delete file if exists
   rm -f ${file_path}.resource-meta.xml # delete file if exists
-  curl --silent https://www.gstatic.com/agent-assist-ui-modules/v1.11/${file}.js > $file_path
+  curl --silent https://www.gstatic.com/agent-assist-ui-modules/${UIM_COMMON_VERSION}/${file}.js > $file_path
   echo downloaded js and wrote ${file_path}
 
   # create a zip of the ui_modules directory. This avoids Salesforce size limits.


### PR DESCRIPTION
This PR updates CSS styles for the Agent Assist LWC to correct default styling for lists in the Salesforce environment, which Salesforce Lightning Design System removes. It adds back bullets and numbering, and applies the appropriate `padding-start` to align the list with AA suggestion text.