### PR TITLE
Bugfix/df complete conversation

### DIFF
--- a/salesforce/aa-lwc/README.md
+++ b/salesforce/aa-lwc/README.md
@@ -44,3 +44,25 @@ Because of Salesforce's tabbed conversation management, it is neccesary for Agen
     { namespace: uniqueIdForUiModuleInstance } // binds event to namespaced instance
   );
 ```
+
+### Local Configuration and Customization
+
+High-level behavioral configuration parameters (e.g., the Dialogflow API version, polling attempts, delays, token refresh intervals, and console logging throttle rates) are fully centralized in [config.js](file:///Users/jblakey/projects/agent-assist-ui-modules/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/config.js) right next to the main controller:
+
+* **`DIALOGFLOW_API_VERSION`**: Specifies the Dialogflow API version used for API requests (defaults to `"v2beta1"`).
+* **`TOKEN_REFRESH_CHECK_INTERVAL_MS`**: Interval in milliseconds to automatically check and refresh UI Connector JWT tokens.
+* **`TOKEN_HEALTHY_LOG_INTERVAL_MS`**: Controls console debug log verbosity by throttling the "Token is healthy" status log to output at most once every X milliseconds (defaults to 5 minutes).
+* **Polling Configuration**: Customize Dialogflow conversation status check retries and delays via `POLL_MAX_RETRIES`, `POLL_INITIAL_DELAY_MS`, and `POLL_DELAY_INCREMENT_MS`.
+
+### Code Quality and Formatting
+
+The LWC codebase uses Prettier (configured via `.prettierrc`) to enforce code formatting and style guidelines. You can run checks and format the source tree using the following scripts:
+
+```bash
+# Verify code style compliance
+npm run lint
+
+# Automatically format and clean the codebase
+npm run lint:fix
+```
+

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/__tests__/agentAssistContainerModule.test.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/__tests__/agentAssistContainerModule.test.js
@@ -18,6 +18,7 @@
 import AgentAssistContainerModule from "c/agentAssistContainerModule";
 import { createElement } from "lwc"; // eslint-disable-line no-unused-vars
 import { loadScript, loadStyle } from "lightning/platformResourceLoader";
+import { DIALOGFLOW_API_VERSION } from "../config";
 
 // Mock platform services to ensure we can verify instantiation without real implementations.
 jest.mock("./../platformServices/MessagingPlatformService", () =>
@@ -419,7 +420,7 @@ describe("c-agent-assist-container-module", () => {
       // fetch called with expected URL containing conversationName
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(
-          "/v2/projects/p/locations/l/conversations/1:ingestContextReferences"
+          `/${DIALOGFLOW_API_VERSION}/projects/p/locations/l/conversations/1:ingestContextReferences`
         ),
         {}
       );

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.css
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.css
@@ -29,8 +29,8 @@
 
 /* Sets a max height and fixed height on the transcript to support (auto) scrolling */
 .agent-assist-transcript > * {
-  height: calc(var(--aa-container-height, 710px) - 66px);
-  max-height: calc(var(--aa-container-height, 710px) - 66px);
+  height: calc(var(--aa-container-height, 530px) - 66px);
+  max-height: calc(var(--aa-container-height, 530px) - 66px);
 }
 
 /* Hides a dimensionless LWC specific element that supports Messaging for In-App and Web */
@@ -43,8 +43,8 @@ lightning-service-cloud-voice-toolkit-api {
 /* Gives the transcript-container a fixed height, which lets autoscroll work properly and helps control LWC size */
 .agent-assist-component .transcript-container {
   flex: 2;
-  height: var(--aa-container-height, 710px);
-  max-height: var(--aa-container-height, 710px);
+  height: var(--aa-container-height, 530px);
+  max-height: var(--aa-container-height, 530px);
 }
 
 /* Prevents the footer from not respecting height of buttons with padding when the suggestions container is full */
@@ -55,7 +55,7 @@ lightning-service-cloud-voice-toolkit-api {
 /* Gives the agent-assist-container a fixed height, which matches the transcript height and helps control LWC size */
 .agent-assist-component .agent-assist-container {
   flex: 3;
-  max-height: var(--aa-container-height, 710px);
+  max-height: var(--aa-container-height, 530px);
   min-width: 360px;
 }
 
@@ -74,7 +74,8 @@ lightning-service-cloud-voice-toolkit-api {
 }
 
 /* Fixes misaligned settings button icon */
-.mat-mdc-icon-button .mdc-button__label, .mat-mdc-icon-button .mat-icon {
+.mat-mdc-icon-button .mdc-button__label,
+.mat-mdc-icon-button .mat-icon {
   display: flex;
 }
 
@@ -93,9 +94,7 @@ lightning-service-cloud-voice-toolkit-api {
 }
 
 /* Adds consistent vertical padding to the suggestions container */
-.agent-assist-ui-modules 
-  .main
-  .suggestions-container {
+.agent-assist-ui-modules .main .suggestions-container {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
 }
@@ -158,14 +157,14 @@ lightning-service-cloud-voice-toolkit-api {
 }
 
 .transcript-container.dark-mode {
-    background: #212124;
-    border-right: 1px solid #5f6368
+  background: #212124;
+  border-right: 1px solid #5f6368;
 }
 
 .transcript-container.dark-mode h3 {
-    background: #3c4043;
-    border-color: #212124;
-    color: rgb(218, 220, 224);
+  background: #3c4043;
+  border-color: #212124;
+  color: rgb(218, 220, 224);
 }
 
 .transcript-container.dark-mode ::-webkit-scrollbar-thumb {
@@ -174,12 +173,12 @@ lightning-service-cloud-voice-toolkit-api {
 
 .agent-assist-transcript .conversation-container {
   padding: 8px 0;
+  overflow-y: auto;
 }
-
 
 /* Fixes the participant role icon */
 .container .icon-container .role-icon {
-  line-height: 0 !important;
+  box-sizing: content-box;
 }
 
 /* Load Error =============================================================== */

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.html
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.html
@@ -48,9 +48,7 @@
       lwc:ref="serviceCloudVoiceToolkitApi"
     >
     </lightning-service-cloud-voice-toolkit-api>
-    <lightning-conversation-toolkit-api
-      lwc:ref="conversationToolkitApi"
-    >
+    <lightning-conversation-toolkit-api lwc:ref="conversationToolkitApi">
     </lightning-conversation-toolkit-api>
   </div>
 </template>

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.js
@@ -16,22 +16,27 @@
 
 import { api, wire } from "lwc";
 import { loadScript, loadStyle } from "lightning/platformResourceLoader";
-import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
-import { MessageContext } from 'lightning/messageService';
+import { getRecord, getFieldValue } from "lightning/uiRecordApi";
+import { MessageContext } from "lightning/messageService";
 
 // static resources
 import ui_modules from "@salesforce/resourceUrl/ui_modules";
 import global_styles from "@salesforce/resourceUrl/global_styles";
 import google_logo from "@salesforce/resourceUrl/google_logo";
 
-import { LightningElement } from 'lwc';
-import agentAssistEventNames from './data/agentAssistEventNames';
-import sampleContext from './data/sampleContext';
+import { LightningElement } from "lwc";
+import agentAssistEventNames from "./data/agentAssistEventNames";
+import sampleContext from "./data/sampleContext";
+import {
+  DIALOGFLOW_API_VERSION,
+  TOKEN_REFRESH_CHECK_INTERVAL_MS,
+  CONTEXT_INJECTION_DELAY_MS
+} from "./config";
 
 // Platform Services
-import MessagingPlatformService from './platformServices/MessagingPlatformService';
-import TwilioFlexPlatformService from './platformServices/TwilioFlexPlatformService';
-import ServiceCloudVoicePlatformService from './platformServices/ServiceCloudVoicePlatformService';
+import MessagingPlatformService from "./platformServices/MessagingPlatformService";
+import TwilioFlexPlatformService from "./platformServices/TwilioFlexPlatformService";
+import ServiceCloudVoicePlatformService from "./platformServices/ServiceCloudVoicePlatformService";
 
 // This Zone.js flag must be set to prevent monkey-patching of DOM APIs,
 // some of which are forbidden by Lightning Web Security (LWS).
@@ -141,10 +146,10 @@ export default class AgentAssistContainerModule extends LightningElement {
       // Get a UI Connector auth token
       this.token = await this.platformService.registerAuthToken();
 
-      // Automatically check and refresh the token dynamically every 60 seconds
+      // Automatically check and refresh the token dynamically
       this.tokenRefreshInterval = setInterval(async () => {
         await this.platformService.checkAndRefreshToken();
-      }, 60000);
+      }, TOKEN_REFRESH_CHECK_INTERVAL_MS);
       // Run an initial check immediately
       await this.platformService.checkAndRefreshToken();
 
@@ -254,7 +259,11 @@ export default class AgentAssistContainerModule extends LightningElement {
   debugLog(message) {
     // A debug utility to log messages only if debugMode is set to true.
     if (this.debugMode) {
-      console.log(`%c[AgentAssist]%c ${message}`, "background-color: #0070d2; color: #ffffff; padding: 2px 4px; border-radius: 3px; font-weight: bold;", "");
+      console.log(
+        `%c[AgentAssist]%c ${message}`,
+        "background-color: #0070d2; color: #ffffff; padding: 2px 4px; border-radius: 3px; font-weight: bold;",
+        ""
+      );
     }
   }
 
@@ -275,7 +284,7 @@ export default class AgentAssistContainerModule extends LightningElement {
     // Injects context into the Dialogflow conversation for demos and testing.
     // https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/projects.locations.conversations/ingestContextReferences
     const injectContext = () => {
-      let url = `${this.endpoint}/v2/${this.conversationName}:ingestContextReferences`;
+      let url = `${this.endpoint}/${DIALOGFLOW_API_VERSION}/${this.conversationName}:ingestContextReferences`;
       let body = JSON.stringify({
         contextReferences: {
           context: {
@@ -297,6 +306,6 @@ export default class AgentAssistContainerModule extends LightningElement {
           this.debugLog(`ingestDemoContextReferences failed: ${err.message}`);
         });
     };
-    setTimeout(injectContext, 1000);
+    setTimeout(injectContext, CONTEXT_INJECTION_DELAY_MS);
   }
 }

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.js-meta.xml
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/agentAssistContainerModule.js-meta.xml
@@ -42,8 +42,8 @@
         description="The Consumer Key from your Salesforce Connected App for authentication. [Required]" />
       <property name="consumerSecret" type="String" default="" label="Connected App Consumer Secret"
         description="The Consumer Secret from your Salesforce Connected App for authentication. [Required]" />
-      <property name="containerHeight" type="String" default="710px" label="Container Height"
-        description="The height of the Agent Assist container (e.g. 710px). [Required]" />
+      <property name="containerHeight" type="String" default="530px" label="Container Height"
+        description="The height of the Agent Assist container (e.g. 530px). [Required]" />
       <property name="showDarkModeToggle" type="Boolean" default="true" label="Show Dark Mode Toggle"
         description="Enable the dark mode toggle in the UI Module. [Optional]" />
       <property name="showHeader" type="Boolean" default="false" label="Show Header"

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/config.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/config.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Dialogflow API Configuration
+export const DIALOGFLOW_API_VERSION = "v2beta1";
+
+// Token Refresh & Auth Configuration
+export const TOKEN_REFRESH_CHECK_INTERVAL_MS = 60000;
+export const TOKEN_EXPIRATION_THRESHOLD_SEC = 60;
+export const TOKEN_WAIT_INTERVAL_MS = 100;
+export const TOKEN_HEALTHY_LOG_INTERVAL_MS = 300000;
+
+// Conversation Polling Configuration
+export const POLL_MAX_RETRIES = 15;
+export const POLL_INITIAL_DELAY_MS = 100;
+export const POLL_DELAY_INCREMENT_MS = 100;
+
+// Demo & Testing Configuration
+export const CONTEXT_INJECTION_DELAY_MS = 1000;

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/data/agentAssistEventNames.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/data/agentAssistEventNames.js
@@ -24,6 +24,7 @@ const agentAssistEventNames = [
   "conversation-initialized",
   "conversation-started",
   "conversation-completed",
+  "complete-conversation-requested",
   "conversation-profile-requested",
   "conversation-profile-received",
   "conversation-model-requested",

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/BasePlatformService.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/BasePlatformService.js
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-import agentAssistEventNames from '../data/agentAssistEventNames';
-import sampleContext from '../data/sampleContext';
+import agentAssistEventNames from "../data/agentAssistEventNames";
+import sampleContext from "../data/sampleContext";
+import {
+  DIALOGFLOW_API_VERSION,
+  TOKEN_EXPIRATION_THRESHOLD_SEC,
+  TOKEN_WAIT_INTERVAL_MS,
+  TOKEN_HEALTHY_LOG_INTERVAL_MS,
+  POLL_MAX_RETRIES,
+  POLL_INITIAL_DELAY_MS,
+  POLL_DELAY_INCREMENT_MS
+} from "../config";
+
+let lastTokenHealthyLogTimeMs = 0;
 
 export default class BasePlatformService {
   lwc;
@@ -42,11 +53,11 @@ export default class BasePlatformService {
     // Get a UI Connector auth token using a SF External Client App id token.
     const access_token = await fetch(
       `/services/oauth2/token?` +
-      new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: this.lwc.consumerKey,
-        client_secret: this.lwc.consumerSecret
-      })
+        new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: this.lwc.consumerKey,
+          client_secret: this.lwc.consumerSecret
+        })
     )
       .then((res) => {
         if (!res.ok)
@@ -59,7 +70,9 @@ export default class BasePlatformService {
         this.lwc.loadError = err;
         return null;
       });
-    this.lwc.debugLog(`Salesforce External Client App OAuth Token successfully retrieved.`);
+    this.lwc.debugLog(
+      `Salesforce External Client App OAuth Token successfully retrieved.`
+    );
 
     if (!access_token) {
       return null;
@@ -110,19 +123,28 @@ export default class BasePlatformService {
         const timeUntilExpSec = payload.exp - currentTimeSec;
 
         // Refresh if token is within 1 minute (60s) of expiring
-        if (timeUntilExpSec < 60) {
+        if (timeUntilExpSec < TOKEN_EXPIRATION_THRESHOLD_SEC) {
           this.lwc.debugLog(
-            `Token is expiring in ${timeUntilExpSec}s (threshold 60s). Refreshing...`
+            `Token is expiring in ${timeUntilExpSec}s (threshold ${TOKEN_EXPIRATION_THRESHOLD_SEC}s). Refreshing...`
           );
           this.lwc.token = await this.registerAuthToken();
           if (this.connector) {
             this.connector.setAuthToken(this.lwc.token);
-            this.lwc.debugLog("Auth token successfully updated on UiModulesConnector instance.");
+            this.lwc.debugLog(
+              "Auth token successfully updated on UiModulesConnector instance."
+            );
           }
         } else {
-          this.lwc.debugLog(
-            `Token is healthy. Expires in ${timeUntilExpSec}s.`
-          );
+          const currentTimeMs = Date.now();
+          if (
+            currentTimeMs - lastTokenHealthyLogTimeMs >=
+            TOKEN_HEALTHY_LOG_INTERVAL_MS
+          ) {
+            this.lwc.debugLog(
+              `Token is healthy. Expires in ${timeUntilExpSec}s.`
+            );
+            lastTokenHealthyLogTimeMs = currentTimeMs;
+          }
         }
       }
     } catch (err) {
@@ -154,9 +176,15 @@ export default class BasePlatformService {
     containerEl.setAttribute("namespace", this.lwc.recordId);
 
     // Optional attributes for UI Modules
-    containerEl.setAttribute("show-dark-mode-toggle", this.lwc.showDarkModeToggle);
+    containerEl.setAttribute(
+      "show-dark-mode-toggle",
+      this.lwc.showDarkModeToggle
+    );
     containerEl.setAttribute("show-header", this.lwc.showHeader);
-    containerEl.setAttribute("show-correctness-feedback", this.lwc.showCorrectnessFeedback);
+    containerEl.setAttribute(
+      "show-correctness-feedback",
+      this.lwc.showCorrectnessFeedback
+    );
     containerEl.setAttribute("disabled-features", this.lwc.disabledFeatures);
 
     // Create the UI Modules Connector.
@@ -264,7 +292,9 @@ export default class BasePlatformService {
     // Ensure we have a token before proceeding.
     while (!this.lwc.token) {
       this.lwc.debugLog("waiting for ui connector token...");
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) =>
+        setTimeout(resolve, TOKEN_WAIT_INTERVAL_MS)
+      );
     }
     this.lwc.debugLog(`ui connector token: ${this.lwc.token}`);
 
@@ -282,15 +312,15 @@ export default class BasePlatformService {
   }
 
   async pollDialogflowForConversationExistence(
-    maxRetries = 15,
-    initialDelay = 100
+    maxRetries = POLL_MAX_RETRIES,
+    initialDelay = POLL_INITIAL_DELAY_MS
   ) {
     // Poll for this.conversationName until Dialogflow confirms it exists.
     let delayMs = initialDelay;
     for (let i = 0; i < maxRetries; i++) {
       try {
         const response = await fetch(
-          `${this.lwc.endpoint}/v2beta1/${this.lwc.conversationName}`,
+          `${this.lwc.endpoint}/${DIALOGFLOW_API_VERSION}/${this.lwc.conversationName}`,
           this.createRequestOptions("GET")
         );
         this.lwc.debugLog(
@@ -298,7 +328,7 @@ export default class BasePlatformService {
         );
         if (response.ok) return true; // Conversation exists, exit polling
         await new Promise((resolve) => setTimeout(resolve, delayMs));
-        delayMs += 100;
+        delayMs += POLL_DELAY_INCREMENT_MS;
       } catch (error) {
         this.lwc.debugLog(
           `pollDialogflowForConversationExistence - error: ${error}`
@@ -315,8 +345,8 @@ export default class BasePlatformService {
     // Deletes conversationIntegrationKey:conversationName pair from Redis.
     return await fetch(
       this.lwc.endpoint +
-      "/conversation-name?conversationIntegrationKey=" +
-      conversationIntegrationKey,
+        "/conversation-name?conversationIntegrationKey=" +
+        conversationIntegrationKey,
       this.createRequestOptions("DELETE")
     )
       .then((res) => this.lwc.debugLog(`deleteConversationName: ${res.status}`))
@@ -325,7 +355,7 @@ export default class BasePlatformService {
 
   async fetchConversationLifecycleState() {
     return await fetch(
-      `${this.lwc.endpoint}/v2/${this.lwc.conversationName}`,
+      `${this.lwc.endpoint}/${DIALOGFLOW_API_VERSION}/${this.lwc.conversationName}`,
       this.createRequestOptions("GET")
     )
       .then((res) => res.json())

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/MessagingPlatformService.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/MessagingPlatformService.js
@@ -26,7 +26,8 @@ import conversationEndUserMessageChannel from "@salesforce/messageChannel/lightn
 import conversationEndedChannel from "@salesforce/messageChannel/lightning__conversationEnded";
 import tabClosedChannel from "@salesforce/messageChannel/lightning__tabClosed";
 
-import BasePlatformService from './BasePlatformService';
+import BasePlatformService from "./BasePlatformService";
+import { DIALOGFLOW_API_VERSION } from "../config";
 
 export default class MessagingPlatformService extends BasePlatformService {
   subscriptions = [];
@@ -68,7 +69,7 @@ export default class MessagingPlatformService extends BasePlatformService {
       (event) =>
         this.handleAgentAssistEventForMessaging(
           "agent-coaching-response-selected",
-          event,
+          event
         ),
       { namespace: this.lwc.recordId }
     );
@@ -80,33 +81,33 @@ export default class MessagingPlatformService extends BasePlatformService {
       subscribe(
         this.lwc.messageContext,
         conversationAgentSendChannel,
-        (event) => this.handleMessageSendForMessaging('HUMAN_AGENT', event),
-        { scope: APPLICATION_SCOPE },
-      ),
+        (event) => this.handleMessageSendForMessaging("HUMAN_AGENT", event),
+        { scope: APPLICATION_SCOPE }
+      )
     );
     this.subscriptions.push(
       subscribe(
         this.lwc.messageContext,
         conversationEndUserMessageChannel,
-        (event) => this.handleMessageSendForMessaging('END_USER', event),
-        { scope: APPLICATION_SCOPE },
-      ),
+        (event) => this.handleMessageSendForMessaging("END_USER", event),
+        { scope: APPLICATION_SCOPE }
+      )
     );
     this.subscriptions.push(
       subscribe(
         this.lwc.messageContext,
         conversationEndedChannel,
         (event) => this.handleConversationEndedForMessaging(event),
-        { scope: APPLICATION_SCOPE },
-      ),
+        { scope: APPLICATION_SCOPE }
+      )
     );
     this.subscriptions.push(
       subscribe(
         this.lwc.messageContext,
         tabClosedChannel,
         (event) => this.handleTabClosedForMessaging(event),
-        { scope: APPLICATION_SCOPE },
-      ),
+        { scope: APPLICATION_SCOPE }
+      )
     );
   }
 
@@ -161,7 +162,9 @@ export default class MessagingPlatformService extends BasePlatformService {
     let prefix = this.lwc.projectLocationName;
     this.lwc.conversationId = `SF-${this.lwc.recordId}`;
     this.lwc.conversationName = `${prefix}/conversations/${this.lwc.conversationId}`;
-    this.lwc.debugLog(`this.lwc.conversationName - ${this.lwc.conversationName}`);
+    this.lwc.debugLog(
+      `this.lwc.conversationName - ${this.lwc.conversationName}`
+    );
   }
 
   handleConversationEndedForMessaging(event) {
@@ -170,7 +173,7 @@ export default class MessagingPlatformService extends BasePlatformService {
 
     if (this.lwc.recordId !== event.recordId) return;
     dispatchAgentAssistEvent(
-      "conversation-completed",
+      "complete-conversation-requested",
       { detail: { conversationName: this.lwc.conversationName } },
       { namespace: this.lwc.recordId }
     );

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/ServiceCloudVoicePlatformService.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/ServiceCloudVoicePlatformService.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import TwilioFlexPlatformService from './TwilioFlexPlatformService';
+import TwilioFlexPlatformService from "./TwilioFlexPlatformService";
 
 import scvEventNames from "../data/scvEventNames";
 const SCV_EVENTS_TO_SUBSCRIBE = [

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/TwilioFlexPlatformService.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/TwilioFlexPlatformService.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import BasePlatformService from './BasePlatformService';
+import BasePlatformService from "./BasePlatformService";
 
 export default class TwilioFlexPlatformService extends BasePlatformService {
   pollingTimeout = null;
@@ -26,14 +26,15 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
 
   constructor(lwc, refs) {
     super(lwc, refs);
-    this.handleConversationEndedForTwilioFlex = this.handleConversationEndedForTwilioFlex.bind(this);
+    this.handleConversationEndedForTwilioFlex =
+      this.handleConversationEndedForTwilioFlex.bind(this);
   }
 
   async init() {
     // Set up Agent Assist UIM to work with Twilio Flex
-    this.lwc.debugLog('initTwilioFlex called');
+    this.lwc.debugLog("initTwilioFlex called");
     this.lwc.conversationName = await this.fetchConversationName(
-      this.lwc.contactPhone,
+      this.lwc.contactPhone
     );
     if (
       !this.lwc.conversationName ||
@@ -57,12 +58,12 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
   ////////////////////////////////////////////////////////////////////////////
 
   listenToAgentAssistEventsForTwilioFlex() {
-    this.lwc.debugLog('listenToAgentAssistEventsForTwilioFlex called');
+    this.lwc.debugLog("listenToAgentAssistEventsForTwilioFlex called");
     // Handle Agent Assist events
     addAgentAssistEventListener(
       "conversation-completed",
       this.handleConversationEndedForTwilioFlex,
-      { namespace: this.lwc.recordId },
+      { namespace: this.lwc.recordId }
     );
   }
 
@@ -79,9 +80,9 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
     try {
       const response = await fetch(
         this.lwc.endpoint +
-           '/conversation-name?conversationIntegrationKey=' +
-           conversationIntegrationKey,
-        { ...this.createRequestOptions('GET'), signal: controller.signal },
+          "/conversation-name?conversationIntegrationKey=" +
+          conversationIntegrationKey,
+        { ...this.createRequestOptions("GET"), signal: controller.signal }
       );
 
       if (response?.ok) {
@@ -89,16 +90,16 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
         return data.conversationName;
       } else if (response && response.status !== 404) {
         this.lwc.debugLog(
-          `Error fetching conversation name: ${response.status} ${response.statusText}`,
+          `Error fetching conversation name: ${response.status} ${response.statusText}`
         );
       }
     } catch (error) {
-      if (error.name === 'AbortError') {
+      if (error.name === "AbortError") {
         // Re-throw the abort error so the poller can catch it and stop.
         throw error;
       } else {
         this.lwc.debugLog(
-          `Network error fetching conversation name: ${error.message}`,
+          `Network error fetching conversation name: ${error.message}`
         );
       }
     } finally {
@@ -109,11 +110,7 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
 
   async pollForConversationNameByIntegrationKey(
     conversationIntegrationKey,
-    {
-      initialDelay = 1000,
-      maxDelay = 10000,
-      requestTimeoutMs = 9900,
-    } = {},
+    { initialDelay = 1000, maxDelay = 10000, requestTimeoutMs = 9900 } = {}
   ) {
     // Poll continuously for a conversationName with a backoff.
     // It starts polling rapidly, then cools down to a 10-second interval.
@@ -122,27 +119,33 @@ export default class TwilioFlexPlatformService extends BasePlatformService {
 
     const poll = async (delayMs) => {
       attempt++;
-      this.lwc.debugLog(`Polling for conversationName... (attempt ${attempt}, delay: ${delayMs}ms)`);
+      this.lwc.debugLog(
+        `Polling for conversationName... (attempt ${attempt}, delay: ${delayMs}ms)`
+      );
 
       try {
         this.lwc.conversationName = await this.fetchConversationName(
           conversationIntegrationKey,
-          requestTimeoutMs,
+          requestTimeoutMs
         );
 
         if (
           this.lwc.conversationName &&
           !(await this.isConversationCompleted(conversationIntegrationKey))
         ) {
-          this.lwc.debugLog(`Found conversationName: ${this.lwc.conversationName}. Initializing UI Modules.`);
+          this.lwc.debugLog(
+            `Found conversationName: ${this.lwc.conversationName}. Initializing UI Modules.`
+          );
           this.handleConnectorInitialized();
           this.initUIModules();
           return; // Stop polling on success
         } else {
-          throw new Error('Conversation not found or already completed.'); // Force retry
+          throw new Error("Conversation not found or already completed."); // Force retry
         }
       } catch (error) {
-        this.lwc.debugLog(`Polling attempt ${attempt} failed: ${error.message}`);
+        this.lwc.debugLog(
+          `Polling attempt ${attempt} failed: ${error.message}`
+        );
 
         // Calculate the next delay with a linear increase, capped at maxDelay.
         // This reaches maxDelay in ~10 attempts.

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/__tests__/BasePlatformService.test.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/__tests__/BasePlatformService.test.js
@@ -15,7 +15,12 @@
  */
 
 import BasePlatformService from "../BasePlatformService";
-import { setupPlatformServiceTest, createMockLwcComponent, createMockRefs } from "../testUtils";
+import {
+  setupPlatformServiceTest,
+  createMockLwcComponent,
+  createMockRefs
+} from "../testUtils";
+import { DIALOGFLOW_API_VERSION } from "../../config";
 
 describe("BasePlatformService", () => {
   let mockLwc;
@@ -388,7 +393,7 @@ describe("BasePlatformService", () => {
         await basePlatformService.fetchConversationLifecycleState();
 
       expect(global.fetch).toHaveBeenCalledWith(
-        "https://test-endpoint.com/v2/test-conversation-name",
+        `https://test-endpoint.com/${DIALOGFLOW_API_VERSION}/test-conversation-name`,
         {
           method: "GET",
           headers: {

--- a/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/__tests__/MessagingPlatformService.test.js
+++ b/salesforce/aa-lwc/force-app/main/default/lwc/agentAssistContainerModule/platformServices/__tests__/MessagingPlatformService.test.js
@@ -16,10 +16,15 @@
 
 // Mock the message channels by creating a mock file in jest-mocks
 // This approach avoids the module resolution issues
-jest.mock('lightning/messageService');
+jest.mock("lightning/messageService");
 import MessagingPlatformService from "../MessagingPlatformService";
 import { subscribe, unsubscribe } from "lightning/messageService";
-import { setupPlatformServiceTest, createMockLwcComponent, createMockRefs } from "../testUtils";
+import {
+  setupPlatformServiceTest,
+  createMockLwcComponent,
+  createMockRefs
+} from "../testUtils";
+import { DIALOGFLOW_API_VERSION } from "../../config";
 
 describe("MessagingPlatformService", () => {
   let mockLwc;
@@ -30,6 +35,12 @@ describe("MessagingPlatformService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({})
+    });
 
     mockLwc = createMockLwcComponent({
       consumerKey: "test-key",
@@ -70,7 +81,7 @@ describe("MessagingPlatformService", () => {
     messagingPlatformService = new MessagingPlatformService(mockLwc, mockRefs);
   });
 
-  afterEach(() => {});
+  afterEach(() => { });
 
   describe("constructor", () => {
     it("initializes with lwc and refs parameters", () => {
@@ -232,23 +243,23 @@ describe("MessagingPlatformService", () => {
       jest.useRealTimers();
     });
 
-    it("dispatches conversation-completed event", () => {
+    it("dispatches complete-conversation-requested event", () => {
       const event = {
-        recordId: "test-record-id",
+        recordId: "test-record-id"
       };
 
       messagingPlatformService.handleConversationEndedForMessaging(event);
 
       expect(global.dispatchAgentAssistEvent).toHaveBeenCalledWith(
-        "conversation-completed",
+        "complete-conversation-requested",
         { detail: { conversationName: "test-conversation-name" } },
         { namespace: "test-record-id" }
       );
     });
 
-    it("does not dispatch conversation-completed event when recordId does not match", () => {
+    it("does not dispatch complete-conversation-requested event when recordId does not match", () => {
       const event = {
-        recordId: "different-record-id",
+        recordId: "different-record-id"
       };
 
       messagingPlatformService.handleConversationEndedForMessaging(event);
@@ -258,7 +269,7 @@ describe("MessagingPlatformService", () => {
 
     it("should call triggerSummarization after a timeout", () => {
       const event = {
-        recordId: "test-record-id",
+        recordId: "test-record-id"
       };
 
       messagingPlatformService.handleConversationEndedForMessaging(event);

--- a/salesforce/aa-lwc/force-app/main/default/staticresources/global_styles.css
+++ b/salesforce/aa-lwc/force-app/main/default/staticresources/global_styles.css
@@ -16,23 +16,6 @@
 
 /* UIM v2 CSS Adjustments for LWC - These rules affect elements outside the component root that need to be unscoped */
 
-/* Fixes button icon misalignment */
-.mat-mdc-button>.mat-icon, .mat-mdc-unelevated-button>.mat-icon, .mat-mdc-raised-button>.mat-icon, .mat-mdc-outlined-button>.mat-icon, .mat-tonal-button>.mat-icon {
-  line-height: var(--slds-spacing-none) !important;
-}
-
-/* Adds padding bottom to loading spinner in summary modal */
-.mat-mdc-dialog-container .summary__content .mat-mdc-progress-spinner.mdc-circular-progress.mat-primary {
-  margin-bottom: var(--slds-spacing-xx-large);
-}
-
-/* Adds a margin to the bottom of the loading spinner in the knowledge search container */
-.mat-mdc-progress-spinner.mdc-circular-progress.mat-primary.mdc-circular-progress--indeterminate.gmat-mdc-progress-spinner {
-  margin-top: var(--slds-spacing-medium);
-  margin-bottom: var(--slds-spacing-medium);
-}
-
-/* Fixes modal scrolling */
-.summary-dialog .summary__content-wrapper .summary__content {
-  max-height: unset;
-}
+/* Currently no global CSS adjustments are needed.
+   This is desirable to avoid CSS drift from the core UI Modules.
+   If issues arise later, then add the necessary CSS here. */

--- a/salesforce/aa-lwc/force-app/test/jest-mocks/lightning/conversationToolkitApi.js
+++ b/salesforce/aa-lwc/force-app/test/jest-mocks/lightning/conversationToolkitApi.js
@@ -9,7 +9,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/salesforce/aa-lwc/force-app/test/jest-mocks/lightning/logger.js
+++ b/salesforce/aa-lwc/force-app/test/jest-mocks/lightning/logger.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const log = console.log
+export const log = console.log;

--- a/salesforce/aa-lwc/package.json
+++ b/salesforce/aa-lwc/package.json
@@ -10,7 +10,9 @@
     "test": "sfdx-lwc-jest --",
     "test:verbose": "sfdx-lwc-jest -- --verbose",
     "test:coverage": "sfdx-lwc-jest -- --coverage --verbose",
-    "test:log": "SHOW_LOGS=true sfdx-lwc-jest -- --testNamePattern"
+    "test:log": "SHOW_LOGS=true sfdx-lwc-jest -- --testNamePattern",
+    "lint": "prettier --check \"force-app/**/*.{js,html,css}\"",
+    "lint:fix": "prettier --write \"force-app/**/*.{js,html,css}\""
   },
   "author": "Jordan",
   "license": "Apache-2.0",


### PR DESCRIPTION
bugfix(salesforce): complete Dialogflow conversations using complete-conversation-requested` to trigger real-time Insights ingestion

This ensures that ending a Salesforce Chat session immediately calls Dialogflow's `:complete` proxy endpoint, forcing immediate session closure and real-time ingestion into the Dialogflow Insights Dashboard.

FIXES=https://b.corp.google.com/issues/509941587
TESTED=unit tests and manual e2e tests in SF LWC environment.

Change-Id: [I9d4f7dc9f67e3203be1ae2a77b39c915791a1df6](https://partner-code-review.git.corp.google.com/q/I9d4f7dc9f67e3203be1ae2a77b39c915791a1df6)